### PR TITLE
Load the database file from the bundle for the APTimeZones class rather ...

### DIFF
--- a/APTimeZones/APTimeZones.m
+++ b/APTimeZones/APTimeZones.m
@@ -98,7 +98,7 @@
  Import from DB
  */
 - (NSArray *)importDataBaseFromFile:(NSString *)fileName {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:fileName ofType:nil];
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:fileName ofType:nil];
     NSData *jsonData = [NSData dataWithContentsOfFile:filePath];
     
     NSAssert(jsonData.length != 0, @"timezonesDB.json not found in app bundle");


### PR DESCRIPTION
...than mainBundle so it will be found when APTimeZones is included in a framework or bundle.